### PR TITLE
Use a custom assert macro

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ $(TESTS): $(DEPS_OBJS) $(OBJS)
 
 test: $(TESTS)
 	@echo "\nRunning sphia tests"
-	@$(foreach e,$(TESTS:%.c=%),./$(basename $(e)) && echo "  ✓ $(e)";)
+	@$(foreach e, $(TESTS:%.c=%), ./$(basename $(e)) && echo "  ✓ $(e)";)
 	@echo
 
 install: $(MAN_FILES) build

--- a/test/set-similar-keys.c
+++ b/test/set-similar-keys.c
@@ -14,7 +14,6 @@ test_similar_keys() {
   assert(-1 != sphia_set(sphia, k2, v2));
 
   char *res = sphia_get(sphia, k1);
-  printf("%s == %s\n", v1, res);
   assert(0 == strcmp(v1, res));
 }
 

--- a/test/sphia-test.h
+++ b/test/sphia-test.h
@@ -1,9 +1,26 @@
 
-#ifndef __SPHIA_TEST_H__
-#define __SPHIA_TEST_H__ 1
+#ifndef SPHIA_TEST_H
+#define SPHIA_TEST_H 1
 
-#include <assert.h>
 #include "../src/api.h"
+
+int __failed_assertions = 0;
+
+/*
+ * Simple assertion macro which records
+ * count of failed assertions
+ */
+
+#define assert(expr) ({ \
+  if (!(expr)) { \
+    __failed_assertions++; \
+    fprintf(stderr \
+      , "Assertion error: %s (%s:%d)\n" \
+      , #expr \
+      , __FILE__ \
+      , __LINE__); \
+  } \
+})
 
 sphia_t *sphia;
 
@@ -11,9 +28,9 @@ sphia_t *sphia;
   sphia = sphia_new("./test-db"); \
   assert(sphia != NULL); \
   func(); \
-  sphia_clear(sphia); \
+  assert(-1 != sphia_clear(sphia)); \
   sphia_free(sphia); \
-  return 0; \
+  return __failed_assertions; \
 }
 
 #endif


### PR DESCRIPTION
This allows for checks to fail and our teardown (`sphia_clear`) to still run.  Otherwise, we’ll have a corrupted database after any assertion fails.
